### PR TITLE
Improve accessibility for button "dismiss"

### DIFF
--- a/projects/angular2-cookie-law/src/lib/angular2-cookie-law.component.html
+++ b/projects/angular2-cookie-law/src/lib/angular2-cookie-law.component.html
@@ -16,5 +16,6 @@
     <a href="#" role="button"
                 class="dismiss"
                 [innerHTML]="closeSvg"
-                (click)="dismiss($event)"></a>
+                (click)="dismiss($event)"
+                [attr.aria-label]="closeSvg"></a>
 </div>


### PR DESCRIPTION
Add aria-label attribute on dismiss button because it does not have a discernible text : https://dequeuniversity.com/rules/axe/2.2/button-name