### PR TITLE
Default seen to true when not a platform browser

### DIFF
--- a/projects/angular2-cookie-law/src/lib/angular2-cookie-law.service.ts
+++ b/projects/angular2-cookie-law/src/lib/angular2-cookie-law.service.ts
@@ -23,6 +23,8 @@ export class Angular2CookieLawService {
 
     if (isPlatformBrowser(this.platform)) {
       cookies = this.doc.cookie.split(';');
+    } else {
+      return true;
     }
 
     return this.cookieExisits(cookieName, cookies);


### PR DESCRIPTION
When transferring state from SSR to browser users who have seen the notice would be flashed briefly with the notice before browser hides it based on the cookie. I propose it would default to true initial state and be turned on by cookie if needed instead.